### PR TITLE
Fix/Auth_Bug - 인증 페이지 관련 각종 버그 픽스

### DIFF
--- a/components/pages/auth/BottomButton.tsx
+++ b/components/pages/auth/BottomButton.tsx
@@ -5,7 +5,7 @@ interface Props {
   variant?: 'primary' | 'secondary' | 'ghost' | 'light';
   isFullWidth?: boolean;
   to?: string;
-  text: string;
+  text: React.ReactNode;
   children?: React.ReactNode;
   isDisabled?: boolean;
   type?: 'button' | 'submit' | 'reset';

--- a/components/pages/auth/ConfirmIdentity/ConfirmForm.tsx
+++ b/components/pages/auth/ConfirmIdentity/ConfirmForm.tsx
@@ -1,6 +1,7 @@
 import Button from '@/components/ui/Button';
 import { useIdentityStore } from '@/hooks/stores/useIdentityStore';
 import { checkVerification, requestVerification } from '@/service/auth';
+import Toast from '@/utils/notification';
 import React, { useEffect, useRef, useState } from 'react';
 import { shallow } from 'zustand/shallow';
 
@@ -41,7 +42,9 @@ export default function ConfirmForm({ setIsActive }: Props) {
       setIsLoading(true);
       setTimer(180);
     } catch (e) {
-      console.error('인증 요청 실패', e);
+      if (e instanceof Error) {
+        Toast.error(e.message);
+      }
     }
   };
 
@@ -58,7 +61,9 @@ export default function ConfirmForm({ setIsActive }: Props) {
         setIsDuplicatedRequest(false);
         inputRef.current?.focus();
       } catch (e) {
-        console.error('재인증 요청 실패', e);
+        if (e instanceof Error) {
+          Toast.error(e.message);
+        }
       }
       return;
     }
@@ -72,11 +77,13 @@ export default function ConfirmForm({ setIsActive }: Props) {
         setPhoneNum(phoneNumber);
         setTimer(0); // 타이머 값 리셋
       } else {
-        alert('인증번호가 일치하지 않습니다.');
+        Toast.error('인증번호가 일치하지 않습니다.');
         setIsDuplicatedRequest(true);
       }
     } catch (e) {
-      console.error('인증 요청 실패', e);
+      if (e instanceof Error) {
+        Toast.error(e.message);
+      }
     }
   };
 

--- a/components/pages/auth/EmailLogin/index.tsx
+++ b/components/pages/auth/EmailLogin/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { loginWithEmailAndPassword } from '@/service/auth';
+import Toast from '@/utils/notification';
 import BottomButton from '../BottomButton';
 
 interface Props {
@@ -20,7 +21,9 @@ export default function EmailLogin({ title }: Props) {
       window.location.href = '/';
     } catch (e) {
       setError('"아이디 또는 비밀번호가 일치하지 않습니다. 다시 입력해주세요"');
-      console.error('Error logging in:', e);
+      if (e instanceof Error) {
+        Toast.error(e.message);
+      }
     }
   };
 

--- a/components/pages/auth/FindChange/index.tsx
+++ b/components/pages/auth/FindChange/index.tsx
@@ -4,9 +4,9 @@ import React, { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { sendEmailChangeVerificationLink, findUserEmail } from '@/service/auth';
 import Toast from '@/utils/notification';
-import BottomButton from '../BottomButton';
-import TabButton from './TabButton';
 import LoadingIcon from '@/public/loading.svg';
+import TabButton from './TabButton';
+import BottomButton from '../BottomButton';
 
 export type TabType = 'findId' | 'changePwd';
 const tabInfo = {

--- a/components/pages/auth/FindChange/index.tsx
+++ b/components/pages/auth/FindChange/index.tsx
@@ -6,18 +6,15 @@ import { sendEmailChangeVerificationLink, findUserEmail } from '@/service/auth';
 import Toast from '@/utils/notification';
 import BottomButton from '../BottomButton';
 import TabButton from './TabButton';
+import LoadingIcon from '@/public/loading.svg';
 
 export type TabType = 'findId' | 'changePwd';
 const tabInfo = {
   findId: {
-    nameText: '닉네임',
-    namePlaceholder: '닉네임을 기입해주세요',
     confirmText: '가입한 휴대폰으로 찾기',
     confirmPlaceholder: '(-)를 제외한 숫자만 입력',
   },
   changePwd: {
-    nameText: '이름',
-    namePlaceholder: '이름(실명)을 기입해주세요',
     confirmText: '아이디(이메일)',
     confirmPlaceholder: '가입한 아이디를 기입해주세요',
   },
@@ -31,6 +28,7 @@ export default function FindChange() {
   const [name, setName] = useState('');
   const [confirmContent, setConfirmContent] = useState('');
   const [isSuccess, setIsSuccess] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState({
     email: '',
     registrationDate: '',
@@ -52,8 +50,10 @@ export default function FindChange() {
       }
     } else {
       try {
+        setIsLoading(true);
         await sendEmailChangeVerificationLink({ name, email: confirmContent });
         setResult((prev) => ({ ...prev, email: confirmContent }));
+        setIsLoading(false);
         setIsSuccess(true);
       } catch (e) {
         if (e instanceof Error) {
@@ -69,6 +69,15 @@ export default function FindChange() {
     setConfirmContent('');
     setIsSuccess(false);
   };
+
+  const buttonChild =
+    activeTab === 'changePwd' && isLoading ? (
+      <div className="flex items-center justify-center h-auto">
+        <LoadingIcon className="w-7 h-7 animate-spin" />
+      </div>
+    ) : (
+      '확인'
+    );
 
   const renderBody = {
     result: (
@@ -120,14 +129,14 @@ export default function FindChange() {
           {/* eslint-disable jsx-a11y/label-has-associated-control */}
           <div className="flex flex-col gap-2">
             <label htmlFor="name" className="body1 text-grey-800">
-              {tabInfo[activeTab].nameText}
+              이름
             </label>
             <input
               id="name"
               value={name}
               className="h-[58px] rounded-[10px] text-xs 2xs:body1 placeholder-grey-400 py-4 px-5 border-none ring-1 focus:ring-1 focus:ring-grey-200 ring-grey-200"
               type="text"
-              placeholder={tabInfo[activeTab].namePlaceholder}
+              placeholder="이름(실명)을 기입해주세요"
               onChange={(e) => setName(e.target.value)}
             />
           </div>
@@ -151,7 +160,7 @@ export default function FindChange() {
           <BottomButton
             isDisabled={!name || !confirmContent}
             type="submit"
-            text="확인"
+            text={buttonChild}
             isFullWidth
             variant="primary"
             handleClick={handleFindChange}

--- a/components/pages/auth/Profile/index.tsx
+++ b/components/pages/auth/Profile/index.tsx
@@ -110,6 +110,7 @@ export default function Profile({ title }: { title: string }) {
                 petType: petInfo.species,
               },
             ],
+            briefIntroduction: `${petInfo.name}(${petInfo.species})`,
           },
         });
       } else {
@@ -134,6 +135,7 @@ export default function Profile({ title }: { title: string }) {
                 petType: petInfo.species,
               },
             ],
+            briefIntroduction: `${petInfo.name}(${petInfo.species})`,
           },
         });
         // for getting token

--- a/components/pages/auth/Profile/index.tsx
+++ b/components/pages/auth/Profile/index.tsx
@@ -17,6 +17,7 @@ import {
   loginWithEmailAndPassword,
 } from '@/service/auth';
 import { Species } from '@/types/types';
+import Toast from '@/utils/notification';
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRef, useState } from 'react';
@@ -147,7 +148,9 @@ export default function Profile({ title }: { title: string }) {
       setIsLoading(false);
       router.push(`/auth/complete`);
     } catch (e) {
-      console.error('fail');
+      if (e instanceof Error) {
+        Toast.error(e.message);
+      }
     }
   };
 

--- a/components/pages/auth/Profile/index.tsx
+++ b/components/pages/auth/Profile/index.tsx
@@ -9,6 +9,7 @@ import { useGeneralRegisterStore } from '@/hooks/stores/useGeneralRegisterStore'
 import { useIdentityStore } from '@/hooks/stores/useIdentityStore';
 import DefaultImg from '@/public/Auth/dog.svg';
 import Pencil from '@/public/Auth/pencil.svg';
+import LoadingIcon from '@/public/loading.svg';
 import Cancel from '@/public/X.svg';
 import {
   createUserWithEmailAndPassword,
@@ -20,7 +21,6 @@ import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRef, useState } from 'react';
 import { shallow } from 'zustand/shallow';
-import LoadingIcon from '@/public/loading.svg';
 
 export default function Profile({ title }: { title: string }) {
   const {

--- a/components/pages/auth/Profile/index.tsx
+++ b/components/pages/auth/Profile/index.tsx
@@ -20,6 +20,7 @@ import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRef, useState } from 'react';
 import { shallow } from 'zustand/shallow';
+import LoadingIcon from '@/public/loading.svg';
 
 export default function Profile({ title }: { title: string }) {
   const {
@@ -55,7 +56,7 @@ export default function Profile({ title }: { title: string }) {
   const [profileName, setProfileName] = useInput(nickname);
   const [petName, setPetName] = useInput(petInfo.name);
   const [uploadedImage, setUploadedImage] = useState<string | null>(null);
-
+  const [isLoading, setIsLoading] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedPet, setSelectedPet] = useState(petInfo.species);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -87,6 +88,7 @@ export default function Profile({ title }: { title: string }) {
       return;
     }
     try {
+      setIsLoading(true);
       if (key) {
         await createUserWithSocialLogin({
           image: imageFile ?? '',
@@ -140,6 +142,7 @@ export default function Profile({ title }: { title: string }) {
           password,
         });
       }
+      setIsLoading(false);
       router.push(`/auth/complete`);
     } catch (e) {
       console.error('fail');
@@ -176,7 +179,13 @@ export default function Profile({ title }: { title: string }) {
     setImageFile(null);
   };
 
-  console.log(imageFile);
+  const buttonChild = isLoading ? (
+    <div className="flex items-center justify-center h-auto">
+      <LoadingIcon className="w-7 h-7 animate-spin" />
+    </div>
+  ) : (
+    '완료'
+  );
 
   return (
     <>
@@ -272,7 +281,7 @@ export default function Profile({ title }: { title: string }) {
         </p>
       </div>
       <BottomButton
-        text="완료"
+        text={buttonChild}
         isFullWidth
         variant="primary"
         isDisabled={!profileName || !petName || !selectedPet}

--- a/components/pages/auth/Profile/index.tsx
+++ b/components/pages/auth/Profile/index.tsx
@@ -55,7 +55,6 @@ export default function Profile({ title }: { title: string }) {
   const [profileName, setProfileName] = useInput(nickname);
   const [petName, setPetName] = useInput(petInfo.name);
   const [uploadedImage, setUploadedImage] = useState<string | null>(null);
-  const [initImage, setInitImage] = useState(false);
 
   const [isOpen, setIsOpen] = useState(false);
   const [selectedPet, setSelectedPet] = useState(petInfo.species);
@@ -148,6 +147,10 @@ export default function Profile({ title }: { title: string }) {
   };
 
   const handleImageUploadButtonClick = () => {
+    // 클릭 시 파일 입력 필드 초기화
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
     fileInputRef.current?.click();
   };
   // TODO: 기본이미지 선택시, 기본이미지로 설정되도록 수정
@@ -162,7 +165,6 @@ export default function Profile({ title }: { title: string }) {
           setUploadedImage(event.target?.result as string);
         };
         reader.readAsDataURL(file);
-        // console.log(file);
         setImageFile(file);
       }
     } catch (error) {
@@ -170,10 +172,11 @@ export default function Profile({ title }: { title: string }) {
     }
   };
   const CancelImageSelect = () => {
-    setInitImage(true);
     setUploadedImage(null);
     setImageFile(null);
   };
+
+  console.log(imageFile);
 
   return (
     <>
@@ -185,7 +188,7 @@ export default function Profile({ title }: { title: string }) {
         <div className="flex flex-col items-center w-full gap-[12px]">
           <div className="rounded-full border border-grey-200 w-[100px] h-[100px] bg-white relative">
             <div className="rounded-full w-[94px] h-[94px] bg-grey-200 relative top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
-              {uploadedImage && !initImage ? (
+              {uploadedImage ? (
                 <>
                   <Image
                     src={uploadedImage}

--- a/components/pages/auth/Register/AuthForm.tsx
+++ b/components/pages/auth/Register/AuthForm.tsx
@@ -1,6 +1,7 @@
 import { ValidateInput } from '@/components/ui/Input/ValidateInput';
 import { useGeneralRegisterStore } from '@/hooks/stores/useGeneralRegisterStore';
 import { isDuplicatedEmail } from '@/service/auth';
+import Toast from '@/utils/notification';
 import { validate } from '@/utils/validate';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -56,7 +57,9 @@ export default function AuthForm({ setIsActive }: Props) {
       const response = await isDuplicatedEmail(emailAddress);
       return !response.duplicate; // 중복되지 않은 경우 true 반환
     } catch (error) {
-      console.error('Error checking duplicate email:', error);
+      if (error instanceof Error) {
+        Toast.error(error.message);
+      }
       return false; // 오류 발생 시 false 반환
     }
   }, []);

--- a/components/pages/auth/SocialButton.tsx
+++ b/components/pages/auth/SocialButton.tsx
@@ -40,7 +40,8 @@ export default function SocialButton({
   const ButtonIcon = socialMap[socialProvider];
   const buttonStyle = `${sizes[size].btn} rounded-full ${bgColor[socialProvider]} flex items-center justify-center ${hasBorder}`;
   const handleLogin = (provider: string) => {
-    const url = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/${provider}?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_URL}/auth/policy`;
+    // Redirect URI는 백에서 정의되고 있습니다. > ?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_URL}/auth/policy
+    const url = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/${provider}`;
     console.log(url);
     router.push(url);
   };

--- a/components/pages/main/layout/Sidebar/BottomButtonContainer.tsx
+++ b/components/pages/main/layout/Sidebar/BottomButtonContainer.tsx
@@ -2,6 +2,7 @@ import Logout from '@/public/sidebar/logout.svg';
 import ArrowRightIcon from '@/public/arrow-right.svg';
 import { cn } from '@/utils/common';
 import { logout } from '@/service/auth';
+import Toast from '@/utils/notification';
 
 export default function BottomButtonContainer({
   isSidebarOpen,
@@ -11,8 +12,14 @@ export default function BottomButtonContainer({
   handleClick: () => void;
 }) {
   const handleLogout = async () => {
-    await logout();
-    window.location.href = '/';
+    try {
+      await logout();
+      window.location.href = '/';
+    } catch (e) {
+      if (e instanceof Error) {
+        Toast.error(e.message);
+      }
+    }
   };
 
   return (

--- a/types/types.ts
+++ b/types/types.ts
@@ -58,6 +58,7 @@ export interface Body {
   nickname: string;
   noImage: boolean;
   petInfos: PetInfo[];
+  briefIntroduction: string;
 }
 
 export interface PetInfo {


### PR DESCRIPTION
## Fix #76

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 업데이트 (포맷팅, 로컬 변수)
- [ ] 리팩토링
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타... 설명:

## Key Change
1. 회원가입 요청시 briefIntroduction 추가
    - 유저가 입력하는 뎁스를 없애고 ``펫닉네임(펫 종류)`` 를 강제로 넣어준다. 이는 이후 마이페이지에서 수정가능
2. 소셜로그인할 때, 로컬에서 개발시 토큰을 못 받는 현상 (서버에서 확인 중) / 배포된 곳에서 테스트할 때, 소셜 로그인 uri 진입 성공
    - 유저는 배포된 클라이언트 토메인에서 네이버를 제외한 소셜로그인을 진행할 수 있다.
3. 인증 관련 api 에러 처리
    - Toast.error를 사용하여 서버에서 응답하는 에러코드에 대한 에러메시지를 인증 관련 api 실패시 표시한다.
4. 회원 가입 마지막 단계에서 프로필 이미지 업로드의 경우 취소 후 동일한 이미지 재업로드시 적용이 안되는 버그 해결
    - input에 ref를 걸어줘서 pen icon을 클릭하면 사진 업로드 함수를 실행시키는 로직이다. 이미지를 업로드하고 취소 버튼을 눌렀을 때 fileInputRef를 클릭하여 파일 선택 다이얼로그를 열면, 브라우저는 동일한 파일을 다시 선택하는 것을 허용하지 않을 수 있다. 브라우저의 보안 및 개인 정보 보호를 위한 정책이라고 한다. 일한 파일을 다시 선택하지 못하도록 하는 기능을 해제하기위해서 필드를 초기화해주는 과정을 추가했다.
5. 로그아웃 토큰 리셋 요청
    - 서버에서 로그아웃시 토큰 리셋을 해주었다. 따라서, 로그아웃하면 브라우저에서 인증관련 쿠키가 없어지고 로그인페이지로 진입한다.
6. 아이디 찾기
    - 피그마에서 아이디 찾기를 할 때, 닉네임을 요구했는데, 실명으로 변경되었고 이를 적용하였다.


## To Reviewers
현재 네이버 소셜로그인의 경우 정식오픈 후 검수 요청해야 소셜로그인 이용 가능합니다. 
로컬에서 테스트를 원한다면 테스터 등록을 해야 로그인을 진행할 수 있습니다.
테스터 등록은 경우님께 요청바랍니다.

- 아래는 제가 로컬에서 개발할 때, 변경된 key값들입니다. 참고 부탁드립니다.
```
.env.development
NEXT_PUBLIC_RUN_MODE=development
NEXT_PUBLIC_SOCKET_URL=/endpoint/ws
NEXT_PUBLIC_API_URL=https://pawpawdev.duckdns.org
# NEXT_PUBLIC_CLIENT_URL=https://pawpaw-phi.vercel.app
NEXT_PUBLIC_CLIENT_URL=http://localhost:3000

.env.production
NEXT_PUBLIC_RUN_MODE=production
NEXT_PUBLIC_SOCKET_URL=https://socket.paw-paw.xyz/ws
# NEXT_PUBLIC_API_URL=https://api.paw-paw.xyz
# NEXT_PUBLIC_CLIENT_URL=https://www.paw-paw.xyz
# for testing
NEXT_PUBLIC_API_URL=https://pawpawdev.duckdns.org
NEXT_PUBLIC_CLIENT_URL=http://localhost.com:3000
```
